### PR TITLE
upgrade Elasticsearch 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![build status](https://api.travis-ci.org/allegro/embedded-elasticsearch.svg)
 ![Maven Central](https://maven-badges.herokuapp.com/maven-central/pl.allegro.tech/embedded-elasticsearch/badge.svg)
 
-Small utility for creating integration tests that uses Elasticsearch. Instead of using `Node` it downloads elastic search in specified version and starts it in seprate process. It also allows you to install required plugins which is not possible when using `NodeBuilder`. Utility was tested with 2.x version of Elasticsearch.
+Small utility for creating integration tests that uses Elasticsearch. Instead of using `Node` it downloads elastic search in specified version and starts it in seprate process. It also allows you to install required plugins which is not possible when using `NodeBuilder`. Utility was tested with 5.x version of Elasticsearch.
 
 ## Introduction
 
@@ -11,7 +11,7 @@ All you need to do to use this tool is create `EmbeddedElastic` instance. To do 
 
 ```
 final embeddedElastic = EmbeddedElastic.builder()
-        .withElasticVersion("2.2.0")
+        .withElasticVersion("5.0.0")
         .withPortNumber(9300)
         .withClusterName("my_cluster")
         .withIndex("cars", IndexSettings.builder()

--- a/build.gradle
+++ b/build.gradle
@@ -29,14 +29,18 @@ project.version = scmVersion.version
 project.group = 'pl.allegro.tech'
 
 dependencies {
-    compile group: 'org.elasticsearch', name: 'elasticsearch', version: '2.2.0'
+    compile group: 'org.elasticsearch', name: 'elasticsearch', version: '5.0.0'
+    compile group: 'org.elasticsearch.client', name: 'transport', version: '5.0.0'
+    compile group: 'com.google.guava', name: 'guava', version: '18.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.6.2'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'
     compile group: 'commons-io', name: 'commons-io', version: '2.5'
-    compile group: 'net.lingala.zip4j', name: 'zip4j', version: '1.3.2'
+    compile group: 'org.zeroturnaround', name: 'zt-zip', version: '1.10'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
 
     testCompile group: 'org.codehaus.groovy', name: 'groovy', version: '2.4.6'
     testCompile group: 'org.spockframework', name: 'spock-core', version: '1.0-groovy-2.4'
+    testCompile group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.6.2'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'org.skyscreamer', name: 'jsonassert', version: '1.3.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jul 19 22:34:03 CEST 2016
+#Mon Nov 07 19:43:50 CET 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticDownloadUrlUtils.java
+++ b/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticDownloadUrlUtils.java
@@ -15,7 +15,7 @@ class ElasticDownloadUrlUtils {
     static URL urlFromVersion(String elasticVersion) {
         assertVersionValid(elasticVersion);
         try {
-            return new URL("https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/" + elasticVersion + "/elasticsearch-" + elasticVersion + ".zip");
+            return new URL("https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-" + elasticVersion + ".zip");
         } catch (MalformedURLException e) {
             throw propagate(e);
         }

--- a/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticServer.java
+++ b/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticServer.java
@@ -96,7 +96,7 @@ class ElasticServer {
     }
     
     private List<String> elasticStartCommand() {
-        return asList(elasticExecutable(), "--transport.tcp.port=" + instanceDescription.getPort(), "--cluster.name=" + instanceDescription.getClusterName());
+        return asList(elasticExecutable(), "-Etransport.tcp.port=" + instanceDescription.getPort(), "-Ecluster.name=" + instanceDescription.getClusterName());
     }
 
     private String elasticExecutable() {
@@ -125,7 +125,7 @@ class ElasticServer {
         }
         if (line.contains("] started")) {
             signalElasticStarted();
-        } else if (line.contains("[transport") && line.contains("bound_addresses")) {
+        } else if (line.contains("[o.e.t.TransportService") && line.contains("bound_addresses")) {
             tryExtractTransportPort(line);
         } else if (line.contains(", pid[")) {
             tryExtractPid(line);

--- a/src/main/java/pl/allegro/tech/embeddedelasticsearch/EmbeddedElastic.java
+++ b/src/main/java/pl/allegro/tech/embeddedelasticsearch/EmbeddedElastic.java
@@ -1,11 +1,6 @@
 package pl.allegro.tech.embeddedelasticsearch;
 
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.InetSocketTransportAddress;
-import org.elasticsearch.search.SearchHit;
+import static java.util.stream.Collectors.toList;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,8 +16,12 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toList;
-import static org.elasticsearch.common.settings.Settings.settingsBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.transport.client.PreBuiltTransportClient;
 
 public final class EmbeddedElastic {
 
@@ -73,13 +72,11 @@ public final class EmbeddedElastic {
      * @throws UnknownHostException in case when literal 'localhost' cannot be resolved by OS
      */
     public Client createClient() throws UnknownHostException {
-        Settings settings = settingsBuilder()
+        Settings settings = Settings.builder()
                 .put("cluster.name", instanceDescription.getClusterName())
                 .build();
 
-        return TransportClient.builder()
-                .settings(settings)
-                .build()
+        return new PreBuiltTransportClient(settings)
                 .addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("localhost"), instanceDescription.getPort()));
     }
 

--- a/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/ElasticDownloadUrlUtilsSpec.groovy
+++ b/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/ElasticDownloadUrlUtilsSpec.groovy
@@ -14,8 +14,8 @@ class ElasticDownloadUrlUtilsSpec extends Specification {
 
     def "should extract properly version from normal url"() {
         given:
-            final downloadUrl = new URL("https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/2.3.4/elasticsearch-2.3.4.zip")
-            final version = "2.3.4"
+            final downloadUrl = new URL("https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0.zip")
+            final version = "5.0.0"
         when:
             final extractedVersion = ElasticDownloadUrlUtils.versionFromUrl(downloadUrl)
         then:

--- a/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/ElasticInfo.groovy
+++ b/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/ElasticInfo.groovy
@@ -2,10 +2,10 @@ package pl.allegro.tech.embeddedelasticsearch
 
 interface ElasticInfo {
     
-    static final ELASTIC_VERSION = "2.2.0"
-    static final ELASTIC_DOWNLOAD_URL = new URL("https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/2.2.0/elasticsearch-2.2.0.zip")
+    static final ELASTIC_VERSION = "5.0.0"
+    static final ELASTIC_DOWNLOAD_URL = new URL("https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0.zip")
     
-    static final DECOMPOUND_PLUGIN = "decompound"
-    static final DECOMPOUND_PLUGIN_DOWNLOAD_URL = new URL("http://xbib.org/repository/org/xbib/elasticsearch/plugin/elasticsearch-analysis-decompound/2.2.0.0/elasticsearch-analysis-decompound-2.2.0.0-plugin.zip")
+    static final ANALYSIS_ICU_PLUGIN = "analysis-icu"
+    static final ANALYSIS_ICU_PLUGIN_DOWNLOAD_URL = new URL("https://artifacts.elastic.co/downloads/elasticsearch-plugins/analysis-icu/analysis-icu-5.0.0.zip")
     
 }

--- a/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticSpec.groovy
+++ b/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticSpec.groovy
@@ -6,26 +6,15 @@ import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.common.transport.InetSocketTransportAddress
 import org.elasticsearch.index.query.QueryBuilders
+import org.elasticsearch.transport.client.PreBuiltTransportClient
 import org.skyscreamer.jsonassert.JSONAssert
 import spock.lang.Shared
 import spock.lang.Specification
 
-import static ElasticInfo.DECOMPOUND_PLUGIN
-import static ElasticInfo.DECOMPOUND_PLUGIN_DOWNLOAD_URL
 import static ElasticInfo.ELASTIC_VERSION
-import static SampleIndices.AMERICAN_PSYCHO
-import static SampleIndices.AUDIO_BOOK_INDEX_TYPE
-import static SampleIndices.BOOKS_INDEX
-import static SampleIndices.BOOKS_INDEX_NAME
-import static SampleIndices.CARS_INDEX
-import static SampleIndices.CARS_INDEX_NAME
-import static SampleIndices.CAR_INDEX_TYPE
-import static SampleIndices.CLUSTER_NAME
-import static SampleIndices.FIAT_126p
-import static SampleIndices.PAPER_BOOK_INDEX_TYPE
-import static SampleIndices.PORT
-import static SampleIndices.SHINING
-import static SampleIndices.toJson
+import static SampleIndices.*
+import static pl.allegro.tech.embeddedelasticsearch.ElasticInfo.ANALYSIS_ICU_PLUGIN
+import static pl.allegro.tech.embeddedelasticsearch.ElasticInfo.ANALYSIS_ICU_PLUGIN_DOWNLOAD_URL
 
 class EmbeddedElasticSpec extends Specification {
     
@@ -35,7 +24,7 @@ class EmbeddedElasticSpec extends Specification {
     def setupSpec() {
         embeddedElastic = EmbeddedElastic.builder()
                 .withElasticVersion(ELASTIC_VERSION)
-                .withPlugin(DECOMPOUND_PLUGIN, DECOMPOUND_PLUGIN_DOWNLOAD_URL)
+                .withPlugin(ANALYSIS_ICU_PLUGIN, ANALYSIS_ICU_PLUGIN_DOWNLOAD_URL)
                 .withPortNumber(PORT)
                 .withClusterName(CLUSTER_NAME)
                 .withIndex(CARS_INDEX_NAME, CARS_INDEX)
@@ -164,8 +153,8 @@ class EmbeddedElasticSpec extends Specification {
     }
     
     Client createClient() {
-        Settings settings = Settings.settingsBuilder().put("cluster.name", SampleIndices.CLUSTER_NAME).build();
-        TransportClient client = TransportClient.builder().settings(settings).build();
+        Settings settings = Settings.builder().put("cluster.name", SampleIndices.CLUSTER_NAME).build();
+        TransportClient client = new PreBuiltTransportClient(settings);
         client.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName(SampleIndices.HOST), SampleIndices.PORT));
         return client;
     }


### PR DESCRIPTION
Upgrade Elasticsearch to 5.0 and it's runtime dependencies.

Due to (Java API) breaking changes [1][2] such as:

 * logging via Log4j 2 [3] exclusively
 * change the inner structure of the plugins zip
 * add a dedicated client/transport project for transport-client

the implementation does not support Elasticsearch version
less than 5.x.

Closes #4.

[1] https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_java_api_changes.html
[2] https://www.elastic.co/guide/en/elasticsearch/reference/5.0/release-notes-5.0.0.html
[3] http://logging.apache.org/log4j/2.x/