### PR TITLE
Extended installation settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ And that's all, you can connect to your embedded-elastic instance on specified p
 | `withPlugin(String expression)` | plugin that should be installed into Elasticsearch; treat expression as argument to `./elasticsearch-plugin install <expression>` command; use multiple times for multiple plugins |
 | `withIndex(String indexName, IndexSettings indexSettings)` | specify index that should be created and managed by EmbeddedElastic |
 | `withStartTimeout(long value, TimeUnit unit)` | specify timeout you give Elasticsearch to start |
+| `withInstallationDirectory(File installationDirectory)` | specify custom installation directory |
+| `withCleanInstallationDirectoryOnStop(boolean cleanInstallationDirectoryOnStop)` | specify whether clean the installation directory after Elasticsearch stop |
 | `withEsJavaOpts(String javaOpts)` | value of `ES_JAVA_OPTS` variable to be set for Elasticsearch process |
 | `getTransportTcpPort()` | get transport tcp port number used by Elasticsearch instance |
 | `getHttpPort()` | get http port number used by Elasticsearch instance |

--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
@@ -26,13 +26,15 @@ class ElasticSearchInstaller {
     private static final String ELS_PACKAGE_PREFIX = "elasticsearch-";
     private static final List<String> ELS_EXECUTABLE_FILES = Arrays.asList("elasticsearch", "elasticsearch.in.sh");
 
-    private final File baseDirectory = new File(System.getProperty("java.io.tmpdir"), "embedded-elasticsearch-temp-dir");
+    private final File baseDirectory;
     private final InstanceSettings instanceSettings;
     private final InstallationDescription installationDescription;
 
     ElasticSearchInstaller(InstanceSettings instanceSettings, InstallationDescription installationDescription) {
         this.instanceSettings = instanceSettings;
         this.installationDescription = installationDescription;
+        this.baseDirectory = installationDescription.getInstallationDirectory()
+                .orElseGet(() -> new File(System.getProperty("java.io.tmpdir"), "embedded-elasticsearch-temp-dir"));
     }
 
     File getExecutableFile() {

--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticServer.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticServer.java
@@ -23,6 +23,7 @@ class ElasticServer {
     private final File installationDirectory;
     private final File executableFile;
     private final long startTimeoutInMs;
+    private final boolean cleanInstallationDirectoryOnStop;
 
     private boolean started;
     private final Object startedLock = new Object();
@@ -33,11 +34,12 @@ class ElasticServer {
     private volatile int httpPort = -1;
     private volatile int transportTcpPort = -1;
 
-    ElasticServer(String esJavaOpts, File installationDirectory, File executableFile, long startTimeoutInMs) {
+    ElasticServer(String esJavaOpts, File installationDirectory, File executableFile, long startTimeoutInMs, boolean cleanInstallationDirectoryOnStop) {
         this.esJavaOpts = esJavaOpts;
         this.installationDirectory = installationDirectory;
         this.executableFile = executableFile;
         this.startTimeoutInMs = startTimeoutInMs;
+        this.cleanInstallationDirectoryOnStop = cleanInstallationDirectoryOnStop;
     }
 
     void start() throws IOException, InterruptedException {
@@ -191,8 +193,10 @@ class ElasticServer {
     }
 
     private void finalizeClose() {
-        logger.info("Removing installation directory...");
-        deleteInstallationDirectory();
+        if (this.cleanInstallationDirectoryOnStop) {
+            logger.info("Removing installation directory...");
+            deleteInstallationDirectory();
+        }
         logger.info("Finishing...");
         started = false;
     }

--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/InstallationDescription.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/InstallationDescription.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.embeddedelasticsearch;
 
 import org.apache.commons.io.FilenameUtils;
 
+import java.io.File;
 import java.net.URL;
 import java.util.List;
 import java.util.Optional;
@@ -13,10 +14,14 @@ class InstallationDescription {
     private final String version;
     private final URL downloadUrl;
     private final List<Plugin> plugins;
+    private final boolean cleanInstallationDirectoryOnStop;
+    private final Optional<File> installationDirectory;
 
     InstallationDescription(
             Optional<String> versionMaybe,
             Optional<URL> downloadUrlMaybe,
+            Optional<File> installationDirectory,
+            boolean cleanInstallationDirectoryOnStop,
             List<Plugin> plugins) {
         require(versionMaybe.isPresent() || downloadUrlMaybe.isPresent(), "You must specify elasticsearch version, or download url");
         if (versionMaybe.isPresent()) {
@@ -27,6 +32,8 @@ class InstallationDescription {
             this.downloadUrl = downloadUrlMaybe.get();
         }
         this.plugins = plugins;
+        this.cleanInstallationDirectoryOnStop = cleanInstallationDirectoryOnStop;
+        this.installationDirectory = installationDirectory;
     }
 
     String getVersion() {
@@ -43,6 +50,14 @@ class InstallationDescription {
 
     boolean versionIs1x() {
         return version.startsWith("1.");
+    }
+
+    boolean isCleanInstallationDirectoryOnStop() {
+        return cleanInstallationDirectoryOnStop;
+    }
+
+    Optional<File> getInstallationDirectory() {
+        return installationDirectory;
     }
 
     static class Plugin {

--- a/es17-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticSpec.groovy
+++ b/es17-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticSpec.groovy
@@ -27,6 +27,7 @@ import static pl.allegro.tech.embeddedelasticsearch.SampleIndices.FIAT_126p
 import static pl.allegro.tech.embeddedelasticsearch.SampleIndices.PAPER_BOOK_INDEX_TYPE
 import static pl.allegro.tech.embeddedelasticsearch.SampleIndices.SHINING
 import static pl.allegro.tech.embeddedelasticsearch.SampleIndices.toJson
+import static EmbeddedElasticConfiguration.TEST_START_TIMEOUT
 
 class EmbeddedElasticSpec extends Specification {
 
@@ -41,7 +42,7 @@ class EmbeddedElasticSpec extends Specification {
             .withSetting(CLUSTER_NAME, CLUSTER_NAME_VALUE)
             .withIndex(CARS_INDEX_NAME, CARS_INDEX)
             .withIndex(BOOKS_INDEX_NAME, BOOKS_INDEX)
-            .withStartTimeout(1, MINUTES)
+            .withStartTimeout(TEST_START_TIMEOUT, MINUTES)
             .build()
             .start()
 

--- a/es17-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticSpec.groovy
+++ b/es17-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticSpec.groovy
@@ -14,6 +14,7 @@ import static SampleIndices.AudioBook
 import static SampleIndices.Car
 import static SampleIndices.PaperBook
 import static java.util.concurrent.TimeUnit.MINUTES
+import static pl.allegro.tech.embeddedelasticsearch.EmbeddedElasticConfiguration.TEST_ES_JAVA_OPTS
 import static pl.allegro.tech.embeddedelasticsearch.PopularProperties.CLUSTER_NAME
 import static pl.allegro.tech.embeddedelasticsearch.PopularProperties.TRANSPORT_TCP_PORT
 import static pl.allegro.tech.embeddedelasticsearch.SampleIndices.AMERICAN_PSYCHO
@@ -37,7 +38,7 @@ class EmbeddedElasticSpec extends Specification {
 
     static EmbeddedElastic embeddedElastic = EmbeddedElastic.builder()
             .withElasticVersion(ELASTIC_VERSION)
-            .withEsJavaOpts("-Xms128m -Xmx512m")
+            .withEsJavaOpts(TEST_ES_JAVA_OPTS)
             .withSetting(TRANSPORT_TCP_PORT, TRANSPORT_TCP_PORT_VALUE)
             .withSetting(CLUSTER_NAME, CLUSTER_NAME_VALUE)
             .withIndex(CARS_INDEX_NAME, CARS_INDEX)

--- a/es17-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationSpec.groovy
+++ b/es17-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationSpec.groovy
@@ -5,6 +5,9 @@ import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.client.HttpClients
 import spock.lang.Specification
 
+import static java.util.concurrent.TimeUnit.MINUTES
+import static pl.allegro.tech.embeddedelasticsearch.EmbeddedElasticConfiguration.TEST_START_TIMEOUT
+
 class PluginsInstallationSpec extends Specification {
 
     static final HTTP_PORT_VALUE = 9200
@@ -62,6 +65,7 @@ class PluginsInstallationSpec extends Specification {
         return EmbeddedElastic.builder()
                 .withElasticVersion("1.7.5")
                 .withEsJavaOpts("-Xms128m -Xmx512m")
+                .withStartTimeout(TEST_START_TIMEOUT, MINUTES)
                 .withSetting(PopularProperties.HTTP_PORT, HTTP_PORT_VALUE)
     }
 

--- a/es17-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationSpec.groovy
+++ b/es17-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationSpec.groovy
@@ -6,6 +6,7 @@ import org.apache.http.impl.client.HttpClients
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.MINUTES
+import static pl.allegro.tech.embeddedelasticsearch.EmbeddedElasticConfiguration.TEST_ES_JAVA_OPTS
 import static pl.allegro.tech.embeddedelasticsearch.EmbeddedElasticConfiguration.TEST_START_TIMEOUT
 
 class PluginsInstallationSpec extends Specification {
@@ -64,7 +65,7 @@ class PluginsInstallationSpec extends Specification {
     EmbeddedElastic.Builder baseEmbeddedElastic() {
         return EmbeddedElastic.builder()
                 .withElasticVersion("1.7.5")
-                .withEsJavaOpts("-Xms128m -Xmx512m")
+                .withEsJavaOpts(TEST_ES_JAVA_OPTS)
                 .withStartTimeout(TEST_START_TIMEOUT, MINUTES)
                 .withSetting(PopularProperties.HTTP_PORT, HTTP_PORT_VALUE)
     }

--- a/es22-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticSpec.groovy
+++ b/es22-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticSpec.groovy
@@ -13,6 +13,7 @@ import static java.util.concurrent.TimeUnit.MINUTES
 import static pl.allegro.tech.embeddedelasticsearch.PopularProperties.CLUSTER_NAME
 import static pl.allegro.tech.embeddedelasticsearch.PopularProperties.TRANSPORT_TCP_PORT
 import static pl.allegro.tech.embeddedelasticsearch.SampleIndices.*
+import static EmbeddedElasticConfiguration.TEST_START_TIMEOUT
 
 class EmbeddedElasticSpec extends Specification {
     
@@ -27,7 +28,7 @@ class EmbeddedElasticSpec extends Specification {
             .withEsJavaOpts("-Xms128m -Xmx512m")
             .withIndex(CARS_INDEX_NAME, CARS_INDEX)
             .withIndex(BOOKS_INDEX_NAME, BOOKS_INDEX)
-            .withStartTimeout(1, MINUTES)
+            .withStartTimeout(TEST_START_TIMEOUT, MINUTES)
             .build()
             .start()
 

--- a/es22-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticSpec.groovy
+++ b/es22-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticSpec.groovy
@@ -10,6 +10,7 @@ import org.skyscreamer.jsonassert.JSONAssert
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.MINUTES
+import static pl.allegro.tech.embeddedelasticsearch.EmbeddedElasticConfiguration.TEST_ES_JAVA_OPTS
 import static pl.allegro.tech.embeddedelasticsearch.PopularProperties.CLUSTER_NAME
 import static pl.allegro.tech.embeddedelasticsearch.PopularProperties.TRANSPORT_TCP_PORT
 import static pl.allegro.tech.embeddedelasticsearch.SampleIndices.*
@@ -25,7 +26,7 @@ class EmbeddedElasticSpec extends Specification {
             .withElasticVersion(ELASTIC_VERSION)
             .withSetting(TRANSPORT_TCP_PORT, TRANSPORT_TCP_PORT_VALUE)
             .withSetting(CLUSTER_NAME, CLUSTER_NAME_VALUE)
-            .withEsJavaOpts("-Xms128m -Xmx512m")
+            .withEsJavaOpts(TEST_ES_JAVA_OPTS)
             .withIndex(CARS_INDEX_NAME, CARS_INDEX)
             .withIndex(BOOKS_INDEX_NAME, BOOKS_INDEX)
             .withStartTimeout(TEST_START_TIMEOUT, MINUTES)

--- a/es22-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationSpec.groovy
+++ b/es22-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationSpec.groovy
@@ -6,6 +6,7 @@ import org.apache.http.impl.client.HttpClients
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.MINUTES
+import static pl.allegro.tech.embeddedelasticsearch.EmbeddedElasticConfiguration.TEST_ES_JAVA_OPTS
 import static pl.allegro.tech.embeddedelasticsearch.EmbeddedElasticConfiguration.TEST_START_TIMEOUT
 
 class PluginsInstallationSpec extends Specification {
@@ -81,7 +82,7 @@ class PluginsInstallationSpec extends Specification {
     EmbeddedElastic.Builder baseEmbeddedElastic() {
         return EmbeddedElastic.builder()
                 .withElasticVersion("2.2.0")
-                .withEsJavaOpts("-Xms128m -Xmx512m")
+                .withEsJavaOpts(TEST_ES_JAVA_OPTS)
                 .withStartTimeout(TEST_START_TIMEOUT, MINUTES)
                 .withSetting(PopularProperties.HTTP_PORT, HTTP_PORT_VALUE)
     }

--- a/es22-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationSpec.groovy
+++ b/es22-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationSpec.groovy
@@ -5,6 +5,9 @@ import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.client.HttpClients
 import spock.lang.Specification
 
+import static java.util.concurrent.TimeUnit.MINUTES
+import static pl.allegro.tech.embeddedelasticsearch.EmbeddedElasticConfiguration.TEST_START_TIMEOUT
+
 class PluginsInstallationSpec extends Specification {
 
     static final HTTP_PORT_VALUE = 9200
@@ -79,6 +82,7 @@ class PluginsInstallationSpec extends Specification {
         return EmbeddedElastic.builder()
                 .withElasticVersion("2.2.0")
                 .withEsJavaOpts("-Xms128m -Xmx512m")
+                .withStartTimeout(TEST_START_TIMEOUT, MINUTES)
                 .withSetting(PopularProperties.HTTP_PORT, HTTP_PORT_VALUE)
     }
 

--- a/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/CustomInstallationDirectorySpec.groovy
+++ b/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/CustomInstallationDirectorySpec.groovy
@@ -7,6 +7,7 @@ import static PopularProperties.CLUSTER_NAME
 import static PopularProperties.TRANSPORT_TCP_PORT
 import static java.util.concurrent.TimeUnit.MINUTES
 import static EmbeddedElasticConfiguration.TEST_START_TIMEOUT
+import static pl.allegro.tech.embeddedelasticsearch.EmbeddedElasticConfiguration.TEST_ES_JAVA_OPTS
 
 @Stepwise
 class CustomInstallationDirectorySpec extends Specification {
@@ -21,7 +22,7 @@ class CustomInstallationDirectorySpec extends Specification {
             .withElasticVersion(ELASTIC_VERSION)
             .withSetting(TRANSPORT_TCP_PORT, TRANSPORT_TCP_PORT_VALUE)
             .withSetting(CLUSTER_NAME, CLUSTER_NAME_VALUE)
-            .withEsJavaOpts("-Xms128m -Xmx512m")
+            .withEsJavaOpts(TEST_ES_JAVA_OPTS)
             .withInstallationDirectory(INSTALLATION_DIRECTORY)
             .withCleanInstallationDirectoryOnStop(false)
             .withStartTimeout(TEST_START_TIMEOUT, MINUTES)
@@ -37,24 +38,24 @@ class CustomInstallationDirectorySpec extends Specification {
     
     def "should install embedded elastic on custom directory"() {
         when:
-        embeddedElastic.start()
+            embeddedElastic.start()
 
         then:
-        INSTALLATION_DIRECTORY.exists()
-        INSTALLATION_DIRECTORY.listFiles()
-                .findAll { it.isDirectory() }
-                .findAll { it.name == ELASTIC_DIRECTORY_NAME }.size() == 1
+            INSTALLATION_DIRECTORY.exists()
+            INSTALLATION_DIRECTORY.listFiles()
+                    .findAll { it.isDirectory() }
+                    .findAll { it.name == ELASTIC_DIRECTORY_NAME }.size() == 1
     }
 
     def "should not delete custom installation directory after stop"() {
         when:
-        embeddedElastic.stop()
+            embeddedElastic.stop()
 
         then:
-        INSTALLATION_DIRECTORY.exists()
-        INSTALLATION_DIRECTORY.listFiles()
-                .findAll { it.isDirectory() }
-                .findAll { it.name == ELASTIC_DIRECTORY_NAME }.size() == 1
+            INSTALLATION_DIRECTORY.exists()
+            INSTALLATION_DIRECTORY.listFiles()
+                    .findAll { it.isDirectory() }
+                    .findAll { it.name == ELASTIC_DIRECTORY_NAME }.size() == 1
     }
 
 }

--- a/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/CustomInstallationDirectorySpec.groovy
+++ b/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/CustomInstallationDirectorySpec.groovy
@@ -1,0 +1,62 @@
+package pl.allegro.tech.embeddedelasticsearch
+
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+import static PopularProperties.CLUSTER_NAME
+import static PopularProperties.TRANSPORT_TCP_PORT
+import static java.util.concurrent.TimeUnit.MINUTES
+
+@Stepwise
+class CustomInstallationDirectorySpec extends Specification {
+    
+    static final ELASTIC_VERSION = "5.4.0"
+    static final TRANSPORT_TCP_PORT_VALUE = 9930
+    static final CLUSTER_NAME_VALUE = "customDirectoryTestCluster"
+    static final File INSTALLATION_DIRECTORY = new File(System.getProperty("java.io.tmpdir"), "embedded-elasticsearch-custom-dir")
+    static final String ELASTIC_DIRECTORY_NAME = "elasticsearch-${ELASTIC_VERSION}"
+
+    static EmbeddedElastic embeddedElastic = EmbeddedElastic.builder()
+            .withElasticVersion(ELASTIC_VERSION)
+            .withSetting(TRANSPORT_TCP_PORT, TRANSPORT_TCP_PORT_VALUE)
+            .withSetting(CLUSTER_NAME, CLUSTER_NAME_VALUE)
+            .withEsJavaOpts("-Xms128m -Xmx512m")
+            .withInstallationDirectory(INSTALLATION_DIRECTORY)
+            .withCleanInstallationDirectoryOnStop(false)
+            .withStartTimeout(1, MINUTES)
+            .build()
+
+    void setupSpec() {
+        INSTALLATION_DIRECTORY.deleteDir()
+    }
+
+    def cleanupSpec() {
+        INSTALLATION_DIRECTORY.deleteDir()
+    }
+    
+    def "should install embedded elastic on custom directory"() {
+        setup:
+        INSTALLATION_DIRECTORY.delete()
+
+        when:
+        embeddedElastic.start()
+
+        then:
+        INSTALLATION_DIRECTORY.exists()
+        INSTALLATION_DIRECTORY.listFiles()
+                .findAll { it.isDirectory() }
+                .findAll { it.name == ELASTIC_DIRECTORY_NAME }.size() == 1
+    }
+
+    def "should not delete custom installation directory after stop"() {
+        when:
+        embeddedElastic.stop()
+
+        then:
+        INSTALLATION_DIRECTORY.exists()
+        INSTALLATION_DIRECTORY.listFiles()
+                .findAll { it.isDirectory() }
+                .findAll { it.name == ELASTIC_DIRECTORY_NAME }.size() == 1
+    }
+
+}

--- a/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/CustomInstallationDirectorySpec.groovy
+++ b/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/CustomInstallationDirectorySpec.groovy
@@ -6,6 +6,7 @@ import spock.lang.Stepwise
 import static PopularProperties.CLUSTER_NAME
 import static PopularProperties.TRANSPORT_TCP_PORT
 import static java.util.concurrent.TimeUnit.MINUTES
+import static EmbeddedElasticConfiguration.TEST_START_TIMEOUT
 
 @Stepwise
 class CustomInstallationDirectorySpec extends Specification {
@@ -23,7 +24,7 @@ class CustomInstallationDirectorySpec extends Specification {
             .withEsJavaOpts("-Xms128m -Xmx512m")
             .withInstallationDirectory(INSTALLATION_DIRECTORY)
             .withCleanInstallationDirectoryOnStop(false)
-            .withStartTimeout(1, MINUTES)
+            .withStartTimeout(TEST_START_TIMEOUT, MINUTES)
             .build()
 
     void setupSpec() {

--- a/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/CustomInstallationDirectorySpec.groovy
+++ b/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/CustomInstallationDirectorySpec.groovy
@@ -35,9 +35,6 @@ class CustomInstallationDirectorySpec extends Specification {
     }
     
     def "should install embedded elastic on custom directory"() {
-        setup:
-        INSTALLATION_DIRECTORY.delete()
-
         when:
         embeddedElastic.start()
 

--- a/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticSpec.groovy
+++ b/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticSpec.groovy
@@ -13,6 +13,7 @@ import static PopularProperties.CLUSTER_NAME
 import static PopularProperties.TRANSPORT_TCP_PORT
 import static java.util.concurrent.TimeUnit.MINUTES
 import static pl.allegro.tech.embeddedelasticsearch.SampleIndices.*
+import static EmbeddedElasticConfiguration.TEST_START_TIMEOUT
 
 class EmbeddedElasticSpec extends Specification {
     
@@ -27,7 +28,7 @@ class EmbeddedElasticSpec extends Specification {
             .withEsJavaOpts("-Xms128m -Xmx512m")
             .withIndex(CARS_INDEX_NAME, CARS_INDEX)
             .withIndex(BOOKS_INDEX_NAME, BOOKS_INDEX)
-            .withStartTimeout(1, MINUTES)
+            .withStartTimeout(TEST_START_TIMEOUT, MINUTES)
             .build()
             .start()
 

--- a/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticSpec.groovy
+++ b/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticSpec.groovy
@@ -12,6 +12,7 @@ import spock.lang.Specification
 import static PopularProperties.CLUSTER_NAME
 import static PopularProperties.TRANSPORT_TCP_PORT
 import static java.util.concurrent.TimeUnit.MINUTES
+import static pl.allegro.tech.embeddedelasticsearch.EmbeddedElasticConfiguration.TEST_ES_JAVA_OPTS
 import static pl.allegro.tech.embeddedelasticsearch.SampleIndices.*
 import static EmbeddedElasticConfiguration.TEST_START_TIMEOUT
 
@@ -25,7 +26,7 @@ class EmbeddedElasticSpec extends Specification {
             .withElasticVersion(ELASTIC_VERSION)
             .withSetting(TRANSPORT_TCP_PORT, TRANSPORT_TCP_PORT_VALUE)
             .withSetting(CLUSTER_NAME, CLUSTER_NAME_VALUE)
-            .withEsJavaOpts("-Xms128m -Xmx512m")
+            .withEsJavaOpts(TEST_ES_JAVA_OPTS)
             .withIndex(CARS_INDEX_NAME, CARS_INDEX)
             .withIndex(BOOKS_INDEX_NAME, BOOKS_INDEX)
             .withStartTimeout(TEST_START_TIMEOUT, MINUTES)

--- a/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationSpec.groovy
+++ b/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationSpec.groovy
@@ -8,6 +8,7 @@ import spock.lang.Specification
 import java.util.concurrent.TimeUnit
 
 import static java.util.concurrent.TimeUnit.MINUTES
+import static pl.allegro.tech.embeddedelasticsearch.EmbeddedElasticConfiguration.TEST_ES_JAVA_OPTS
 import static pl.allegro.tech.embeddedelasticsearch.EmbeddedElasticConfiguration.TEST_START_TIMEOUT
 
 class PluginsInstallationSpec extends Specification {
@@ -66,7 +67,7 @@ class PluginsInstallationSpec extends Specification {
     EmbeddedElastic.Builder baseEmbeddedElastic() {
         return EmbeddedElastic.builder()
                 .withElasticVersion("5.0.0")
-                .withEsJavaOpts("-Xms128m -Xmx512m")
+                .withEsJavaOpts(TEST_ES_JAVA_OPTS)
                 .withStartTimeout(TEST_START_TIMEOUT, MINUTES)
                 .withSetting(PopularProperties.HTTP_PORT, HTTP_PORT_VALUE)
     }

--- a/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationSpec.groovy
+++ b/es50-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationSpec.groovy
@@ -5,6 +5,11 @@ import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.client.HttpClients
 import spock.lang.Specification
 
+import java.util.concurrent.TimeUnit
+
+import static java.util.concurrent.TimeUnit.MINUTES
+import static pl.allegro.tech.embeddedelasticsearch.EmbeddedElasticConfiguration.TEST_START_TIMEOUT
+
 class PluginsInstallationSpec extends Specification {
 
     static final HTTP_PORT_VALUE = 9200
@@ -62,6 +67,7 @@ class PluginsInstallationSpec extends Specification {
         return EmbeddedElastic.builder()
                 .withElasticVersion("5.0.0")
                 .withEsJavaOpts("-Xms128m -Xmx512m")
+                .withStartTimeout(TEST_START_TIMEOUT, MINUTES)
                 .withSetting(PopularProperties.HTTP_PORT, HTTP_PORT_VALUE)
     }
 

--- a/test-base/src/main/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticConfiguration.java
+++ b/test-base/src/main/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticConfiguration.java
@@ -1,0 +1,9 @@
+package pl.allegro.tech.embeddedelasticsearch;
+
+/**
+ * Common test configuration.
+ */
+public interface EmbeddedElasticConfiguration {
+    /** Default start timeout for test configurations. */
+    int TEST_START_TIMEOUT = 2;
+}

--- a/test-base/src/main/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticConfiguration.java
+++ b/test-base/src/main/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticConfiguration.java
@@ -6,4 +6,6 @@ package pl.allegro.tech.embeddedelasticsearch;
 public interface EmbeddedElasticConfiguration {
     /** Default start timeout for test configurations. */
     int TEST_START_TIMEOUT = 1;
+    /** Default Java options for test elasticsearch instances */
+    String TEST_ES_JAVA_OPTS = "-Xms128m -Xmx512m";
 }

--- a/test-base/src/main/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticConfiguration.java
+++ b/test-base/src/main/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticConfiguration.java
@@ -5,5 +5,5 @@ package pl.allegro.tech.embeddedelasticsearch;
  */
 public interface EmbeddedElasticConfiguration {
     /** Default start timeout for test configurations. */
-    int TEST_START_TIMEOUT = 2;
+    int TEST_START_TIMEOUT = 1;
 }


### PR DESCRIPTION
I've added two installation settings which would be good to see from my project perspective:

1. Custom installation directory (added `withInstallationDirectory(File)` method for builder)
2. Option to disable cleaning data directory after each server stop (added `withCleanInstallationDirectoryOnStop(boolean)` method for builder)

The default behavior has not been touched. Any comments are welcome.