### PR TITLE
Separate installation and download directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ And that's all, you can connect to your embedded-elastic instance on specified p
 | `withIndex(String indexName, IndexSettings indexSettings)` | specify index that should be created and managed by EmbeddedElastic |
 | `withStartTimeout(long value, TimeUnit unit)` | specify timeout you give Elasticsearch to start |
 | `withInstallationDirectory(File installationDirectory)` | specify custom installation directory |
-| `withDownloadDirectory(File downloadDirectory)` | specify custom download directory where downloaded distribution paackages will be saved |
+| `withDownloadDirectory(File downloadDirectory)` | specify custom download directory where downloaded distribution packages will be saved |
 | `withCleanInstallationDirectoryOnStop(boolean cleanInstallationDirectoryOnStop)` | specify whether clean the installation directory after Elasticsearch stop |
 | `withEsJavaOpts(String javaOpts)` | value of `ES_JAVA_OPTS` variable to be set for Elasticsearch process |
 | `getTransportTcpPort()` | get transport tcp port number used by Elasticsearch instance |
@@ -117,6 +117,23 @@ If you build your project on Travis, you may have problems with OOM errors when 
             .build()
             .start()
 ```
+
+## Running more then one Elasticsearch instance
+
+There are cases where you might want to run more then one Elasticsearch instance e.g.:
+- running tests of one project in parallel (e.g. using _gradle --parallel_ or _mvn -T1C_)
+- running tests of different projects on the same physical mashine (e.g. Jenkins jobs running on the same server)
+- running integration tests wich require more then elastic search instance
+
+In such situations you should use distinct values for following settings for each instance:
+
+- `withSetting(PopularProperties.TRANSPORT_TCP_PORT, ...)`
+- `withSetting(PopularProperties.HTTP_PORT, ...)`
+- `withInstallationDirectory(...)`
+
+With such configuration *embedded-elasticsearch* will redonload elasticsearch instllation package for every distinct
+instalation directory. To avoid whis behavior and thus reuse downloaded installation package you should
+set common location of downloaded files with `withDownloadDirectory(...)` for every *embedded-elasticsearch* configuration.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ And that's all, you can connect to your embedded-elastic instance on specified p
 | `withIndex(String indexName, IndexSettings indexSettings)` | specify index that should be created and managed by EmbeddedElastic |
 | `withStartTimeout(long value, TimeUnit unit)` | specify timeout you give Elasticsearch to start |
 | `withInstallationDirectory(File installationDirectory)` | specify custom installation directory |
+| `withDownloadDirectory(File downloadDirectory)` | specify custom download directory where downloaded distribution paackages will be saved |
 | `withCleanInstallationDirectoryOnStop(boolean cleanInstallationDirectoryOnStop)` | specify whether clean the installation directory after Elasticsearch stop |
 | `withEsJavaOpts(String javaOpts)` | value of `ES_JAVA_OPTS` variable to be set for Elasticsearch process |
 | `getTransportTcpPort()` | get transport tcp port number used by Elasticsearch instance |

--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
@@ -13,7 +13,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit ;
+import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.io.FileUtils.forceMkdir;

--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
@@ -49,14 +49,14 @@ class ElasticSearchInstaller {
     }
 
     void install() throws IOException, InterruptedException {
-        prepareDirectoryies();
+        prepareDirectories();
         installElastic();
         configureElastic();
         installPlugins();
         applyElasticPermissionRights();
     }
 
-    private void prepareDirectoryies() throws IOException {
+    private void prepareDirectories() throws IOException {
         forceMkdir(getInstallationDirectory());
         forceMkdir(getDownloadDirectory());
     }

--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
@@ -138,8 +138,8 @@ class ElasticSearchInstaller {
     }
 
     private boolean maybeDownloading(final File target) {
-        // Poor mans check based on assumption that if other process downloads e file should be modified
-        // at least every 10 seconds as new data being downloaded. This will not work on file system
+        // Check based on assumption that if other thread or jvm is currently downloading file on disk should be modified
+        // at least every 10 seconds as new data is being downloaded. This will not work on file system
         // without support for lastmodified field or on very slow internet connection
         return System.currentTimeMillis() - target.lastModified() < TimeUnit.SECONDS.toMillis(10L);
     }

--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
@@ -13,6 +13,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit ;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.io.FileUtils.forceMkdir;
@@ -23,18 +24,16 @@ import static pl.allegro.tech.embeddedelasticsearch.ElasticDownloadUrlUtils.cons
 class ElasticSearchInstaller {
 
     private static final Logger logger = LoggerFactory.getLogger(ElasticSearchInstaller.class);
+    private static final String ELS_PACKAGE_STATUS_FILE_SUFFIX = "-downloaded";
     private static final String ELS_PACKAGE_PREFIX = "elasticsearch-";
     private static final List<String> ELS_EXECUTABLE_FILES = Arrays.asList("elasticsearch", "elasticsearch.in.sh");
 
-    private final File baseDirectory;
     private final InstanceSettings instanceSettings;
     private final InstallationDescription installationDescription;
 
     ElasticSearchInstaller(InstanceSettings instanceSettings, InstallationDescription installationDescription) {
         this.instanceSettings = instanceSettings;
         this.installationDescription = installationDescription;
-        this.baseDirectory = installationDescription.getInstallationDirectory()
-                .orElseGet(() -> new File(System.getProperty("java.io.tmpdir"), "embedded-elasticsearch-temp-dir"));
     }
 
     File getExecutableFile() {
@@ -42,19 +41,24 @@ class ElasticSearchInstaller {
     }
 
     File getInstallationDirectory() {
-        return getFile(baseDirectory, ELS_PACKAGE_PREFIX + installationDescription.getVersion());
+        return getFile(installationDescription.getInstallationDirectory(), ELS_PACKAGE_PREFIX + installationDescription.getVersion());
+    }
+
+    File getDownloadDirectory() {
+        return getFile(installationDescription.getDownloadDirectory());
     }
 
     void install() throws IOException, InterruptedException {
-        prepareDirectory();
+        prepareDirectoryies();
         installElastic();
         configureElastic();
         installPlugins();
         applyElasticPermissionRights();
     }
 
-    private void prepareDirectory() throws IOException {
-        forceMkdir(baseDirectory);
+    private void prepareDirectoryies() throws IOException {
+        forceMkdir(getInstallationDirectory());
+        forceMkdir(getDownloadDirectory());
     }
 
     private void installElastic() throws IOException {
@@ -109,19 +113,58 @@ class ElasticSearchInstaller {
     }
 
     private Path download(URL source) throws IOException {
-        File target = new File(baseDirectory, constructLocalFileName(source));
+        File target = new File(getDownloadDirectory(), constructLocalFileName(source));
+        File statusFile = new File(target.getParentFile(), target.getName() + ELS_PACKAGE_STATUS_FILE_SUFFIX);
+
+        removeBrokenDownload(target, statusFile);
+
         if (!target.exists()) {
-            logger.info("Downloading : " + source + " to " + target + "...");
-            FileUtils.copyURLToFile(source, target);
-            logger.info("Download complete");
+            download(source, target, statusFile);
+        } else if (!statusFile.exists() && maybeDownloading(target)) {
+            waitForDownload(target, statusFile);
+        } else if (!statusFile.exists()) {
+            throw new IOException("Broken download. File '"  + target + "' exits but status '" + statusFile + "' file wash not created");
         } else {
             logger.info("Download skipped");
         }
         return target.toPath();
     }
 
+    private void removeBrokenDownload(final File target, final File statusFile) throws IOException {
+        if (target.exists() && !statusFile.exists() && !maybeDownloading(target)) {
+            logger.info("Removing broken download file {}", target);
+            FileUtils.forceDelete(target);
+        }
+    }
+
+    private boolean maybeDownloading(final File target) {
+        // Poor mans check based on assumption that if other process downloads e file should be modified
+        // at least every 10 seconds as new data being downloaded. This will not work on file system
+        // without support for lastmodified field or on very slow internet connection
+        return System.currentTimeMillis() - target.lastModified() < TimeUnit.SECONDS.toMillis(10L);
+    }
+
+    private void download(final URL source, final File target, final File statusFile) throws IOException {
+        logger.info("Downloading {} to {} ...", source, target);
+        FileUtils.copyURLToFile(source, target);
+        FileUtils.touch(statusFile);
+        logger.info("Download complete");
+    }
+
+    private void waitForDownload(final File target, final File statusFile) throws IOException {
+        boolean downloaded;
+        do {
+            logger.info("File {} (size={}) is probably being downloaded by another thread/jvm. Waiting ...", target, target.length());
+            downloaded = FileUtils.waitFor(statusFile, 30);
+        } while (!downloaded && maybeDownloading(target));
+        if (!downloaded) {
+            throw new IOException("Broken download. Another party probably failed to download " + target);
+        }
+        logger.info("File was downloaded by another thread/jvm. Download skipped");
+    }
+
     private void install(String what, String relativePath, Path downloadedFile) throws IOException {
-        Path destination = new File(baseDirectory, relativePath).toPath();
+        Path destination = new File(getInstallationDirectory().getParentFile(), relativePath).toPath();
         logger.info("Installing " + what + " into " + destination + "...");
         try {
             ZipFile zipFile = new ZipFile(downloadedFile.toString());
@@ -137,7 +180,7 @@ class ElasticSearchInstaller {
         if (IS_OS_WINDOWS) {
             return;
         }
-        File binDirectory = getFile(baseDirectory, ELS_PACKAGE_PREFIX + installationDescription.getVersion(), "bin");
+        File binDirectory = getFile(getInstallationDirectory(), "bin");
         for (String fn : ELS_EXECUTABLE_FILES) {
             setExecutable(new File(binDirectory, fn));
         }

--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/EmbeddedElastic.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/EmbeddedElastic.java
@@ -204,6 +204,7 @@ public final class EmbeddedElastic {
         private long startTimeoutInMs = 15_000;
         private boolean cleanInstallationDirectoryOnStop = true;
         private Optional<File> installationDirectory = Optional.empty();
+        private Optional<File> downloadDirectory = Optional.empty();
 
         private Builder() {
         }
@@ -223,6 +224,10 @@ public final class EmbeddedElastic {
             return this;
         }
 
+        public Builder withDownloadDirectory(File downloadDirectory) {
+            this.downloadDirectory = Optional.of(downloadDirectory);
+            return this;
+        }
 
         public Builder withCleanInstallationDirectoryOnStop(boolean cleanInstallationDirectoryOnStop) {
             this.cleanInstallationDirectoryOnStop = cleanInstallationDirectoryOnStop;
@@ -284,7 +289,7 @@ public final class EmbeddedElastic {
                     esJavaOpts,
                     settings,
                     new IndicesDescription(indices),
-                    new InstallationDescription(version, downloadUrl, installationDirectory, cleanInstallationDirectoryOnStop, plugins),
+                    new InstallationDescription(version, downloadUrl, downloadDirectory, installationDirectory, cleanInstallationDirectoryOnStop, plugins),
                     startTimeoutInMs);
         }
 

--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/InstallationDescription.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/InstallationDescription.java
@@ -1,25 +1,32 @@
 package pl.allegro.tech.embeddedelasticsearch;
 
-import org.apache.commons.io.FilenameUtils;
+import static org.apache.commons.io.FileUtils.getFile;
 
 import java.io.File;
 import java.net.URL;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
+import org.apache.commons.io.FilenameUtils;
 
 import static pl.allegro.tech.embeddedelasticsearch.Require.require;
 
 class InstallationDescription {
 
+    private static final Supplier<File> DEFAULT_INSTALL_DIR = () -> new File(System.getProperty("java.io.tmpdir"), "embedded-elasticsearch-temp-dir");
+    private static final Supplier<File> DEFAULT_DOWNLOAD_DIR = DEFAULT_INSTALL_DIR;
+
     private final String version;
     private final URL downloadUrl;
     private final List<Plugin> plugins;
     private final boolean cleanInstallationDirectoryOnStop;
-    private final Optional<File> installationDirectory;
+    private final File installationDirectory;
+    private final File downloadDirectory;
 
     InstallationDescription(
             Optional<String> versionMaybe,
             Optional<URL> downloadUrlMaybe,
+            Optional<File> downloadDirectory,
             Optional<File> installationDirectory,
             boolean cleanInstallationDirectoryOnStop,
             List<Plugin> plugins) {
@@ -33,7 +40,8 @@ class InstallationDescription {
         }
         this.plugins = plugins;
         this.cleanInstallationDirectoryOnStop = cleanInstallationDirectoryOnStop;
-        this.installationDirectory = installationDirectory;
+        this.installationDirectory = getFile(installationDirectory.orElseGet(DEFAULT_INSTALL_DIR));
+        this.downloadDirectory = getFile(downloadDirectory.orElseGet(DEFAULT_DOWNLOAD_DIR));
     }
 
     String getVersion() {
@@ -56,8 +64,12 @@ class InstallationDescription {
         return cleanInstallationDirectoryOnStop;
     }
 
-    Optional<File> getInstallationDirectory() {
+    File getInstallationDirectory() {
         return installationDirectory;
+    }
+
+    public File getDownloadDirectory() {
+        return downloadDirectory;
     }
 
     static class Plugin {

--- a/core/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/ValidationSpec.groovy
+++ b/core/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/ValidationSpec.groovy
@@ -1,5 +1,6 @@
 package pl.allegro.tech.embeddedelasticsearch
 
+import org.apache.commons.io.FileUtils
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.MINUTES
@@ -40,6 +41,25 @@ class ValidationSpec extends Specification {
                     .build()
                     .start()
                     .stop()
+        then:
+            noExceptionThrown()
+    }
+
+    def "should construct embedded elastic with minimal required arguments and custom download and install directory"() {
+        when:
+            def uniqId = UUID.randomUUID().toString();
+            def installDir = new File(FileUtils.tempDirectory, "$uniqId-install")
+            def downloadDir = new File(FileUtils.tempDirectory, "$uniqId-download")
+            EmbeddedElastic.builder()
+                    .withDownloadUrl(ELASTIC_DOWNLOAD_URL)
+                    .withStartTimeout(TEST_START_TIMEOUT_IN_MINUTES, MINUTES)
+                    .withDownloadDirectory(downloadDir)
+                    .withInstallationDirectory(installDir)
+                    .build()
+                    .start()
+                    .stop()
+            FileUtils.deleteDirectory(installDir)
+            FileUtils.deleteDirectory(downloadDir)
         then:
             noExceptionThrown()
     }

--- a/es55-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationSpec.groovy
+++ b/es55-test/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationSpec.groovy
@@ -1,5 +1,9 @@
 package pl.allegro.tech.embeddedelasticsearch
 
+import static java.util.concurrent.TimeUnit.MINUTES
+import static pl.allegro.tech.embeddedelasticsearch.EmbeddedElasticConfiguration.START_TIMEOUT_IN_MINUTES
+import static pl.allegro.tech.embeddedelasticsearch.EmbeddedElasticConfiguration.TEST_ES_JAVA_OPTS
+
 class PluginsInstallationSpec extends PluginsInstallationBaseSpec {
 
     static final HTTP_PORT_VALUE = 9200
@@ -7,7 +11,8 @@ class PluginsInstallationSpec extends PluginsInstallationBaseSpec {
     EmbeddedElastic.Builder baseEmbeddedElastic() {
         return EmbeddedElastic.builder()
                 .withElasticVersion("5.5.1")
-                .withEsJavaOpts("-Xms128m -Xmx512m")
+                .withEsJavaOpts(TEST_ES_JAVA_OPTS)
+                .withStartTimeout(START_TIMEOUT_IN_MINUTES, MINUTES)
                 .withSetting(PopularProperties.HTTP_PORT, HTTP_PORT_VALUE)
     }
 


### PR DESCRIPTION
Some times (e.g. when running parallel gradle build - which uses separate JVMs)
it is conviniet to download elastic search distribution only onece and then
on each JVM instantiate elasticsearch instance with different installation directory and  (possibly random) ports.
This is not possible if embedded-elastic uses the same base directory for download and installation as this
results in redownloading elastic search distribution on every JVM'm (assumming each JVM uses separate installation directory).

This commit adds possibility to set different download directory and set it outside of install directory.
By default installDir is the same as downloadDir