### PR TITLE
Destory the process via JAVA API instead of using OS commands

### DIFF
--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticServer.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticServer.java
@@ -177,20 +177,10 @@ class ElasticServer {
     }
 
     private void stopElasticGracefully() throws IOException {
-        if (SystemUtils.IS_OS_WINDOWS) {
-            stopWindows();
-        } else {
-            stopSystemV();
-        }
+        elastic.destroy();
     }
 
-    private void stopWindows() throws IOException {
-        Runtime.getRuntime().exec("taskkill /f /pid " + pid);
-    }
 
-    private void stopSystemV() throws IOException {
-        Runtime.getRuntime().exec("kill " + pid);
-    }
 
     private void finalizeClose() {
         if (this.cleanInstallationDirectoryOnStop) {


### PR DESCRIPTION
Hi,

I'm Oded from wix.com.
We had an issue where the server wouldn't stop when running a build on our CI systems. After some research, it turned out that simply killing the process using Java API does work. I also think it's simpler then using OS API.

Thanks,
Oded