### PR TITLE
Do not throw exception when reading from stdout of ES during shutdown

### DIFF
--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticServer.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticServer.java
@@ -81,7 +81,7 @@ class ElasticServer {
                 }
                 BufferedReader outputStream = new BufferedReader(new InputStreamReader(elastic.getInputStream(), UTF_8));
                 String line;
-                while ((line = outputStream.readLine()) != null) {
+                while ((line = readLine(outputStream)) != null) {
                     logger.info(line);
                     parseElasticLogLine(line);
                 }
@@ -90,6 +90,15 @@ class ElasticServer {
             }
         }, "EmbeddedElsHandler");
         ownerThread.start();
+    }
+
+    private String readLine(BufferedReader outputStream) {
+        try {
+            return outputStream.readLine();
+        } catch (IOException e) {
+            // TODO: catching all types of IOException is not clean, any better solution?
+            return null;
+        }
     }
 
     private void installExitHook() {


### PR DESCRIPTION
Fixes #26, although it could catch accidentally also other types of `IOException`, not just `Stream closed`. 