### PR TITLE
Don't allow to specify both an ES version AND a custom download url

### DIFF
--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/InstallationDescription.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/InstallationDescription.java
@@ -30,7 +30,7 @@ class InstallationDescription {
             Optional<File> installationDirectory,
             boolean cleanInstallationDirectoryOnStop,
             List<Plugin> plugins) {
-        require(versionMaybe.isPresent() || downloadUrlMaybe.isPresent(), "You must specify elasticsearch version, or download url");
+        require(versionMaybe.isPresent() ^ downloadUrlMaybe.isPresent(), "You must specify elasticsearch version, or download url");
         if (versionMaybe.isPresent()) {
             this.version = versionMaybe.get();
             this.downloadUrl = ElasticDownloadUrlUtils.urlFromVersion(versionMaybe.get());


### PR DESCRIPTION
When setting up an EmbeddedElastic instance we've specified both an ES version and a custom download url. Only to discover our custom download url wasn't used. Basically you can't specify both an ES version AND a custom download URL. So it's an exclusive OR instead of a plain OR.