### PR TITLE
HttpClient: Don't release connection immediately

### DIFF
--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/HttpClient.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/HttpClient.java
@@ -13,9 +13,7 @@ class HttpClient {
 
     CloseableHttpResponse execute(HttpRequestBase request) {
         try {
-            CloseableHttpResponse execute = internalHttpClient.execute(request);
-            request.releaseConnection();
-            return execute;
+            return internalHttpClient.execute(request);
         } catch (IOException e) {
             throw new HttpRequestException(e);
         }


### PR DESCRIPTION
Due to immediate call to `request.releaseConnection();` in `pl.allegro.tech.embeddedelasticsearch.HttpClient#execute` the socket could be closed before the end of processing, i.e. when used with "larger" requests at `pl.allegro.tech.embeddedelasticsearch.ElasticRestClient#searchForDocuments`.