### PR TITLE
Skip already installed plugins

### DIFF
--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
@@ -74,9 +74,15 @@ class ElasticSearchInstaller {
     private void installPlugins() throws IOException, InterruptedException {
         File pluginManager = pluginManagerExecutable();
         setExecutable(pluginManager);
+        File pluginsDir = new File(getInstallationDirectory(), "plugins");
+        String[] pluginList = pluginsDir.list();
 
         for (InstallationDescription.Plugin plugin : installationDescription.getPlugins()) {
             logger.info("> " + pluginManager + " install " + plugin.getExpression());
+            if(isPluginInstalled(plugin, pluginList)) {
+               logger.info("> Plugin " + plugin.getPluginName() + " already installed, skipping");
+               continue;
+            }
             ProcessBuilder builder = new ProcessBuilder();
             builder.redirectOutput(Redirect.INHERIT);
             builder.redirectError(Redirect.INHERIT);
@@ -86,6 +92,14 @@ class ElasticSearchInstaller {
                 throw new EmbeddedElasticsearchStartupException("Unable to install plugin: " + plugin);
             }
         }
+    }
+
+    private static boolean isPluginInstalled(InstallationDescription.Plugin plugin, String[] pluginList) {
+        if(pluginList == null) return false;
+        for(String filename : pluginList){
+            if(filename.equals(plugin.getPluginName())) return true;
+        }
+        return false;
     }
 
     private String[] prepareInstallCommand(File pluginManager, InstallationDescription.Plugin plugin) {


### PR DESCRIPTION
Hey there, 
Here's a small addition to the installation process.
In my use case I'm providing a zipped elasticsearch file with already installed plugins in order to prevent them getting downloaded over and over again.

What this change does is, it validates that the plugin we're trying to install is not already present in the plugins folder before attempting a download and installation.
If present, skip it and continue with the next.

Adding tests would probably involve adding elasticsearch installations to the repo which would bloat it unnecessarily, any ideas or preferences?

