### PR TITLE
Install plugin with --batch option in Elasticsearch 5.x or later

### DIFF
--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
@@ -128,7 +128,10 @@ class ElasticSearchInstaller {
         if (installationDescription.versionIs1x() && plugin.expressionIsUrl()) {
             return new String[]{pluginManager.getAbsolutePath(), "--install", plugin.getPluginName(), "--url", plugin.getExpression()};
         }
-        return new String[]{pluginManager.getAbsolutePath(), "install", plugin.getExpression()};
+        if (installationDescription.versionIs1x() || installationDescription.versionIs2x()) {
+            return new String[]{pluginManager.getAbsolutePath(), "install", plugin.getExpression()};
+        }
+        return new String[]{pluginManager.getAbsolutePath(), "install", "--batch", plugin.getExpression()};
     }
 
     private File pluginManagerExecutable() throws IOException {

--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/InstallationDescription.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/InstallationDescription.java
@@ -56,6 +56,10 @@ class InstallationDescription {
         return getVersion().startsWith("1.");
     }
 
+    boolean versionIs2x() {
+        return getVersion().startsWith("2.");
+    }
+
     boolean isCleanInstallationDirectoryOnStop() {
         return cleanInstallationDirectoryOnStop;
     }


### PR DESCRIPTION
This mitigates breaking change https://github.com/elastic/elasticsearch/pull/29359 introduced in Elasticsearch 6.3.0.

Before Elasticsearch 6.3.0, if a plugin requires additional permissions, and standard input is closed or there is no console, then the plugin is installed without asking the user to acknowledge the additional permissions. Elasticsearch 6.3.0 introduced a breaking change where it waits for the user to acknowledge, so an attempt to install such a plugin hangs forever. Elasticsearch 5.x introduced the `--batch` option to install the plugin without asking the user to acknowledge. 