### PR TITLE
idempotent start

### DIFF
--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/EmbeddedElastic.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/EmbeddedElastic.java
@@ -33,7 +33,7 @@ public final class EmbeddedElastic {
 
     private ElasticServer elasticServer;
     private ElasticRestClient elasticRestClient;
-    private boolean started = false;
+    private volatile boolean started = false;
 
     public static Builder builder() {
         return new Builder();

--- a/core/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/SynchronicitySpec.groovy
+++ b/core/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/SynchronicitySpec.groovy
@@ -3,32 +3,24 @@ package pl.allegro.tech.embeddedelasticsearch
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.MINUTES
+import static pl.allegro.tech.embeddedelasticsearch.PopularProperties.HTTP_PORT
 
 class SynchronicitySpec extends Specification {
     static final ELASTIC_VERSION = "2.2.0"
+    static final HTTP_PORT_VALUE = 9999
 
-    def "should not throw exception on starting embedded instance more than once from different threads"() {
+    def "should not throw exception on starting embedded instance more than once"() {
         when:
         final server = EmbeddedElastic.builder()
                 .withElasticVersion(ELASTIC_VERSION)
                 .withStartTimeout(TEST_START_TIMEOUT_IN_MINUTES, MINUTES)
+                .withSetting(HTTP_PORT, HTTP_PORT_VALUE)
                 .build()
-        def errorsInStartup = false
-        final startJob = {
-            try {
-                server.start()
-            } catch(Exception e) {
-                errorsInStartup = true
-            }
-        }
-        final asyncStarter1 = new Thread(startJob)
-        final asyncStarter2 = new Thread(startJob)
-        asyncStarter1.start()
-        asyncStarter2.start()
-        asyncStarter1.join()
-        asyncStarter2.join()
+        server.start()
+        server.start()
+
         then:
-        !errorsInStartup
+        noExceptionThrown()
 
         cleanup:
         server.stop()

--- a/core/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/SynchronicitySpec.groovy
+++ b/core/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/SynchronicitySpec.groovy
@@ -1,0 +1,38 @@
+package pl.allegro.tech.embeddedelasticsearch
+
+import spock.lang.Specification
+
+import static java.util.concurrent.TimeUnit.MINUTES
+
+class SynchronicitySpec extends Specification {
+    static final ELASTIC_VERSION = "2.2.0"
+
+    def "should not throw exception on starting embedded instance more than once from different threads"() {
+        when:
+        final server = EmbeddedElastic.builder()
+                .withElasticVersion(ELASTIC_VERSION)
+                .withStartTimeout(TEST_START_TIMEOUT_IN_MINUTES, MINUTES)
+                .build()
+        def errorsInStartup = false
+        final startJob = {
+            try {
+                server.start()
+            } catch(Exception e) {
+                errorsInStartup = true
+            }
+        }
+        final asyncStarter1 = new Thread(startJob)
+        final asyncStarter2 = new Thread(startJob)
+        asyncStarter1.start()
+        asyncStarter2.start()
+        asyncStarter1.join()
+        asyncStarter2.join()
+        then:
+        !errorsInStartup
+
+        cleanup:
+        server.stop()
+    }
+    static final TEST_START_TIMEOUT_IN_MINUTES = 1
+
+}

--- a/core/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/ValidationSpec.groovy
+++ b/core/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/ValidationSpec.groovy
@@ -8,8 +8,7 @@ import static java.util.concurrent.TimeUnit.MINUTES
 class ValidationSpec extends Specification {
 
     static final ELASTIC_VERSION = "2.2.0"
-    static
-    final ELASTIC_DOWNLOAD_URL = new URL("https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/2.2.0/elasticsearch-2.2.0.zip")
+    static final ELASTIC_DOWNLOAD_URL = new URL("https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/2.2.0/elasticsearch-2.2.0.zip")
 
     def "should throw exception on missing elastic version and download url"() {
         when:


### PR DESCRIPTION
make the `.start()` and `.stop()` methods of EmbeddedElastic Idempotent to themselves (consecutive calls to the same method from different threads will have no effect)

fixes #64 