### PR TITLE
allow user to select JRE to run elasticsearch in

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ And that's all, you can connect to your embedded-elastic instance on specified p
 | `withDownloadDirectory(File downloadDirectory)` | specify custom download directory where downloaded distribution packages will be saved |
 | `withCleanInstallationDirectoryOnStop(boolean cleanInstallationDirectoryOnStop)` | specify whether clean the installation directory after Elasticsearch stop |
 | `withEsJavaOpts(String javaOpts)` | value of `ES_JAVA_OPTS` variable to be set for Elasticsearch process |
+| `withJavaHome(JavaHomeOption javaHomeOption)` | select java environment to run in. For available options see below |
 | `getTransportTcpPort()` | get transport tcp port number used by Elasticsearch instance |
 | `getHttpPort()` | get http port number used by Elasticsearch instance |
 | `withDownloadProxy(Proxy proxy)` | proxy that should be used for downloading Elasticsearch package |
@@ -63,6 +64,16 @@ Available `IndexSettings.Builder` options
 | ------------- | ------------- |
 | `withType(String type, String mapping)` | specify type and it's mappings |
 | `withSettings(String settings)` | specify index settings |
+
+
+Availabe `JavaHomeOption` options
+
+| Method | Description |
+| ------------- | ------------- |
+| `useSystem()` | default behavior, lets elasticsearch startup script determine the JRE to run in |
+| `inheritTestSuite()` | use the same JRE as the process starting it |
+| `path(String path)` | manually set the path of the JRE to execute the embedded elastic |
+
 
 ## Available operations
 

--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticServer.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticServer.java
@@ -33,13 +33,15 @@ class ElasticServer {
     private volatile int pid = -1;
     private volatile int httpPort = -1;
     private volatile int transportTcpPort = -1;
+    private JavaHomeOption javaHome;
 
-    ElasticServer(String esJavaOpts, File installationDirectory, File executableFile, long startTimeoutInMs, boolean cleanInstallationDirectoryOnStop) {
+    ElasticServer(String esJavaOpts, File installationDirectory, File executableFile, long startTimeoutInMs, boolean cleanInstallationDirectoryOnStop, JavaHomeOption javaHome) {
         this.esJavaOpts = esJavaOpts;
         this.installationDirectory = installationDirectory;
         this.executableFile = executableFile;
         this.startTimeoutInMs = startTimeoutInMs;
         this.cleanInstallationDirectoryOnStop = cleanInstallationDirectoryOnStop;
+        this.javaHome = javaHome;
     }
 
     void start() throws InterruptedException {
@@ -75,6 +77,7 @@ class ElasticServer {
                 synchronized (this) {
                     ProcessBuilder builder = new ProcessBuilder();
                     builder.environment().put("ES_JAVA_OPTS", esJavaOpts);
+                    javaHome.ifNeedBeSet(javaHomeValue -> builder.environment().put("JAVA_HOME", javaHomeValue));
                     builder.redirectErrorStream(true);
                     builder.command(elasticExecutable());
                     elastic = builder.start();

--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/JavaHomeOption.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/JavaHomeOption.java
@@ -1,0 +1,86 @@
+package pl.allegro.tech.embeddedelasticsearch;
+
+import java.util.function.Consumer;
+
+/**
+ * select java home to use when running elasticsearch
+ */
+public abstract class JavaHomeOption {
+
+    public abstract boolean shouldBeSet();
+
+    public abstract String getValue();
+
+    public void ifNeedBeSet(Consumer<String> consumer) {
+        if(shouldBeSet()) {
+            consumer.accept(getValue());
+        }
+    }
+
+    public static JavaHomeOption useSystem() {
+        return new JavaHomeOption.UseSystem();
+    }
+
+    public static JavaHomeOption inheritTestSuite() {
+        return new JavaHomeOption.Inherit();
+    }
+
+    public static JavaHomeOption path(String path) {
+        return new JavaHomeOption.Path(path);
+    }
+
+    /**
+     * do not set an option, use the system wide set default
+     */
+    public static class UseSystem extends JavaHomeOption {
+
+        public boolean shouldBeSet() {
+            return false;
+        }
+
+        public String getValue() {
+            return null;
+        }
+    }
+
+    /**
+     * inherit java home from the process running the tests
+     */
+    public static class Inherit extends JavaHomeOption {
+
+        @Override
+        public boolean shouldBeSet() {
+            return true;
+        }
+
+        @Override
+        public String getValue() {
+            return System.getProperty("java.home");
+        }
+    }
+
+    /**
+     * explicitly set java home using a path, e.g.
+     *
+     * new JavaHomeOption.Path("/usr/lib/jvm/java-8-openjdk-amd64/")
+     */
+    public static class Path extends JavaHomeOption {
+
+        String value;
+
+        public Path(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean shouldBeSet() {
+            return true;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+    }
+
+}


### PR DESCRIPTION
this does not break previous behavior as the default remains to rely on
the system default jre

fixes #70