### PR TITLE
#78: Allow to reuse the elastic folder when withCleanInstallationDirectoryOnStop option is set to false

### DIFF
--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/ElasticSearchInstaller.java
@@ -14,12 +14,13 @@ import java.io.InputStreamReader;
 import java.lang.ProcessBuilder.Redirect;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.io.FileUtils.forceMkdir;
 import static org.apache.commons.io.FileUtils.getFile;
 import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 
@@ -48,26 +49,31 @@ class ElasticSearchInstaller {
 
     void install() throws IOException, InterruptedException {
         Path downloadedTo = elasticDownloader.download();
-        prepareDirectories();
         installElastic(downloadedTo);
         configureElastic();
         installPlugins();
     }
 
-    private void prepareDirectories() throws IOException {
-        forceMkdir(getInstallationDirectory());
-    }
-
     private void installElastic(Path downloadedTo) throws IOException {
         File destination = getInstallationDirectory().getParentFile();
-        FileUtils.forceDelete(getInstallationDirectory());
-        logger.info("Installing Elasticsearch" + " into " + destination + "...");
-        try {
-            unzip(downloadedTo, destination);
-            logger.info("Done");
-        } catch (IOException e) {
-            logger.info("Failure : " + e);
-            throw new EmbeddedElasticsearchStartupException(e);
+        if (installationDescription.isCleanInstallationDirectoryOnStop() || !fileRelativeToInstallationDir("bin").exists()) {
+            if (getInstallationDirectory().exists()) {
+                FileUtils.forceDelete(getInstallationDirectory());
+            }
+            logger.info("Installing Elasticsearch into {}...", destination);
+            try {
+                unzip(downloadedTo, destination);
+                logger.info("Done");
+            } catch (IOException e) {
+                logger.info("Failure : " + e);
+                throw new EmbeddedElasticsearchStartupException(e);
+            }
+        } else {
+            logger.info("Cleaning the existing Elasticsearch directory for reuse.");
+            File dataDirectory = fileRelativeToInstallationDir("data");
+            if (dataDirectory.exists()) {
+                FileUtils.forceDelete(dataDirectory);
+            }
         }
     }
 
@@ -81,57 +87,179 @@ class ElasticSearchInstaller {
         FileUtils.writeStringToFile(elasticsearchYml, instanceSettings.toYaml(), UTF_8);
     }
 
+    /**
+     * Installs all the plugins.
+     */
     private void installPlugins() throws IOException, InterruptedException {
         File pluginManager = pluginManagerExecutable();
         Set<String> alreadyInstalledPlugins = getAlreadyInstalledPlugins();
+        Set<String> unusedPlugins = new HashSet<>(alreadyInstalledPlugins);
         for (Plugin plugin : installationDescription.getPlugins()) {
-            if (isPluginInstalled(plugin, (alreadyInstalledPlugins))) {
-                logger.info("> Plugin " + plugin.getPluginName() + " already installed, skipping");
+            if (isPluginInstalled(plugin, alreadyInstalledPlugins)) {
+                unusedPlugins.remove(getPluginName(plugin));
+                logger.info("> Plugin {} already installed, skipping", plugin.getPluginName());
             } else {
                 installPlugin(pluginManager, plugin);
             }
         }
+        uninstallUnusedPlugins(pluginManager, unusedPlugins);
     }
 
+    /**
+     * @param pluginManager the plugin manager to launch to un-install the plugins
+     * @param additionalPlugins all the plugins to un-install.
+     */
+    private void uninstallUnusedPlugins(File pluginManager, Set<String> additionalPlugins) throws IOException, InterruptedException {
+        for (String pluginName : additionalPlugins) {
+            uninstallPlugin(pluginManager, pluginName);
+        }
+    }
+
+    /**
+     * @return the plugins that are already installed.
+     */
     private Set<String> getAlreadyInstalledPlugins() {
         File pluginsDir = new File(getInstallationDirectory(), "plugins");
         String[] pluginList = pluginsDir.list();
-        if (pluginList != null) {
+        if (pluginList != null && pluginList.length > 0) {
             return Stream.of(pluginList).collect(Collectors.toSet());
         } else {
             return Collections.emptySet();
         }
     }
 
-    private void installPlugin(File pluginManager, Plugin plugin) throws IOException, InterruptedException {
-        logger.info("> " + pluginManager + " install " + plugin.getExpression());
+    /**
+     * Executes a command.
+     * @param args the command and its parameters to execute.
+     * @param consumer the consumer of the output of the command
+     * @return the exit value of the command. By convention, the value 0 indicates normal termination.
+     */
+    private int executeCommand(String[] args, Consumer<String> consumer) throws IOException, InterruptedException {
+        // Needed to workaround a bug in 6.3 and 6.4 that prevent calling the command
+        // several times otherwise we get a message of type:
+        // mktemp: cannot make temp dir /tmp/elasticsearch: File exists
+        File tmpDirectory = new File(System.getProperty("java.io.tmpdir"), "elasticsearch");
+        if (tmpDirectory.exists()) {
+            FileUtils.forceDelete(tmpDirectory);
+        }
         ProcessBuilder builder = new ProcessBuilder();
         builder.redirectOutput(Redirect.PIPE);
         builder.redirectErrorStream(true);
-        builder.command(prepareInstallCommand(pluginManager, plugin));
+        builder.command(args);
         Process process = builder.start();
-        BufferedReader bReader = new BufferedReader(new InputStreamReader(process.getInputStream(), UTF_8));
-        String line;
-        while ((line = bReader.readLine()) != null) {
-            logger.info(String.format("Plugin install %s: %s", plugin, line));
-        }
-        if (process.waitFor() != 0) {
-            throw new EmbeddedElasticsearchStartupException("Unable to install plugin: " + plugin);
+        try (BufferedReader bReader = new BufferedReader(new InputStreamReader(process.getInputStream(), UTF_8))) {
+            String line;
+            while ((line = bReader.readLine()) != null) {
+                consumer.accept(line);
+            }
+            return process.waitFor();
+        } finally {
+            if (tmpDirectory.exists()) {
+                FileUtils.forceDelete(tmpDirectory);
+            }
         }
     }
 
-    private static boolean isPluginInstalled(Plugin plugin, Set<String> alreadyInstalledPlugins) {
-        return alreadyInstalledPlugins.contains(plugin.getPluginName());
+    /**
+     * Launches the command that will install the plugin
+     * @param pluginManager the plugin manager to launch to install the plugin
+     * @param plugin the plugin to install
+     */
+    private void installPlugin(File pluginManager, Plugin plugin) throws IOException, InterruptedException {
+        logger.info("> {} install ", pluginManager, plugin.getExpression());
+        if (executeCommand(prepareInstallCommand(pluginManager, plugin), line -> logger.info("Plugin install {}: {}", plugin, line)) != 0) {
+            throw new EmbeddedElasticsearchStartupException(String.format("Unable to install plugin: %s",  plugin));
+        }
     }
 
+    /**
+     * Launches the command that will un-install the plugin
+     * @param pluginManager the plugin manager to launch to uninstall the plugin
+     * @param pluginName the name of the plugin to un-install
+     */
+    private void uninstallPlugin(File pluginManager, String pluginName) throws IOException, InterruptedException {
+        logger.info("> {} uninstall ", pluginManager, pluginName);
+        if (executeCommand(prepareUninstallCommand(pluginManager, pluginName), line -> logger.info("Plugin uninstall {}: {}", pluginName, line)) != 0) {
+            throw new EmbeddedElasticsearchStartupException(String.format("Unable to uninstall plugin: %s", pluginName));
+        }
+    }
+
+    /**
+     * @param plugin the plugin to check
+     * @param alreadyInstalledPlugins the already installed plugins.
+     * @return {@code true} if the plugin has already been installed, {@code false} otherwise.
+     */
+    private boolean isPluginInstalled(Plugin plugin, Set<String> alreadyInstalledPlugins) {
+        return alreadyInstalledPlugins.contains(getPluginName(plugin));
+    }
+
+    /**
+     * @param plugin the plugin from which the name must be extracted
+     * @return the name of the plugin
+     */
+    private String getPluginName(Plugin plugin) {
+        String pluginName = plugin.getPluginName();
+        if (installationDescription.versionIs1x()) {
+            pluginName = extractPluginName(pluginName);
+        }
+        return pluginName;
+    }
+
+    /**
+     * @param name the original name of the plugin
+     * @return the extracted name of the plugin
+     */
+    private String extractPluginName(String name) {
+        String[] elements = name.split("/");
+        String pluginName;
+        if (elements.length > 1) {
+            // We consider the form: username/pluginname or username/pluginname/version
+            pluginName = elements[1];
+        } else {
+            // We consider the simplest form: pluginname
+            pluginName = elements[0];
+        }
+        if (pluginName.startsWith("elasticsearch-")) {
+            // remove elasticsearch- prefix
+            pluginName = pluginName.substring("elasticsearch-".length());
+        } else if (name.startsWith("es-")) {
+            // remove es- prefix
+            pluginName = pluginName.substring("es-".length());
+        }
+        return pluginName;
+    }
+
+    /**
+     * @param pluginManager the plugin manager to launch
+     * @param plugin the plugin to install.
+     * @return the command and its parameters to use to install the given plugin.
+     */
     private String[] prepareInstallCommand(File pluginManager, Plugin plugin) {
-        if (installationDescription.versionIs1x() && plugin.expressionIsUrl()) {
-            return new String[]{pluginManager.getAbsolutePath(), "--install", plugin.getPluginName(), "--url", plugin.getExpression()};
+        if (installationDescription.versionIs1x()) {
+            if (plugin.expressionIsUrl()) {
+                return new String[]{pluginManager.getAbsolutePath(), "--install", plugin.getPluginName(), "--url", plugin.getExpression()};
+            }
+            return new String[]{pluginManager.getAbsolutePath(), "--install", plugin.getPluginName()};
         }
-        if (installationDescription.versionIs1x() || installationDescription.versionIs2x()) {
+        if (installationDescription.versionIs2x()) {
             return new String[]{pluginManager.getAbsolutePath(), "install", plugin.getExpression()};
         }
         return new String[]{pluginManager.getAbsolutePath(), "install", "--batch", plugin.getExpression()};
+    }
+
+    /**
+     * @param pluginManager the plugin manager to launch
+     * @param pluginName the name of the plugin to un-install.
+     * @return the command and its parameters to use to un-install the given plugin.
+     */
+    private String[] prepareUninstallCommand(File pluginManager, String pluginName) {
+        if (installationDescription.versionIs1x()) {
+            return new String[]{pluginManager.getAbsolutePath(), "--remove", pluginName};
+        }
+        if (installationDescription.versionMatchOrAfter("5.5.0")) {
+            return new String[]{pluginManager.getAbsolutePath(), "remove", "--purge", pluginName};
+        }
+        return new String[]{pluginManager.getAbsolutePath(), "remove", pluginName};
     }
 
     private File pluginManagerExecutable() throws IOException {

--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/InstallationDescription.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/InstallationDescription.java
@@ -60,6 +60,37 @@ class InstallationDescription {
         return getVersion().startsWith("2.");
     }
 
+    /**
+     * Indicates whether a given version matches or is after a given reference version.
+     * @param version the version to test.
+     * @param referenceVersion the reference version.
+     * @return {@code true} if the given version matches or is after a given reference version, {@code false} otherwise.
+     */
+    static boolean versionMatchOrAfter(String version, String referenceVersion) {
+        String[] versionsSource = version.split("\\.");
+        String[] versionsTarget = referenceVersion.split("\\.");
+        for (int i = 0; i < versionsSource.length && i < versionsTarget.length; i++) {
+            String versionSource = versionsSource[i];
+            int index = -1;
+            if (i == versionsSource.length - 1) {
+                index = versionSource.indexOf('-');
+                if (index != -1) {
+                    versionSource = versionSource.substring(0, index);
+                }
+            }
+            int iVersionTarget = Integer.parseInt(versionsTarget[i]);
+            int iVersionSource = Integer.parseInt(versionSource);
+            if (iVersionTarget > iVersionSource || (index != -1 && iVersionTarget == iVersionSource)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    boolean versionMatchOrAfter(String startVersion) {
+        return versionMatchOrAfter(getVersion(), startVersion);
+    }
+
     boolean isCleanInstallationDirectoryOnStop() {
         return cleanInstallationDirectoryOnStop;
     }

--- a/core/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/InstallationDescriptionSpec.groovy
+++ b/core/src/test/groovy/pl/allegro/tech/embeddedelasticsearch/InstallationDescriptionSpec.groovy
@@ -1,0 +1,104 @@
+package pl.allegro.tech.embeddedelasticsearch
+
+import spock.lang.Specification
+
+class InstallationDescriptionSpec extends Specification {
+
+    def "should detect previous version with only digits when first digit is smaller"() {
+        when:
+            final result = InstallationDescription.versionMatchOrAfter("1.7.5", "5.5.0")
+        then:
+            !result
+    }
+
+    def "should detect previous alphanumeric version when first digit is smaller"() {
+        when:
+            final result = InstallationDescription.versionMatchOrAfter("1.7.5-rc1", "5.5.0")
+        then:
+            !result
+    }
+
+    def "should detect previous version with only digits when second digit is smaller"() {
+        when:
+            final result = InstallationDescription.versionMatchOrAfter("2.4.5", "5.5.0")
+        then:
+            !result
+    }
+
+    def "should detect previous alphanumeric version when second digit is smaller"() {
+        when:
+            final result = InstallationDescription.versionMatchOrAfter("2.4.5-rc1", "5.5.0")
+        then:
+            !result
+    }
+    
+    def "should detect previous version with only digits when third digit is smaller"() {
+        when:
+            final result = InstallationDescription.versionMatchOrAfter("5.5.0", "5.5.5")
+        then:
+            !result
+    }
+
+    def "should detect previous alphanumeric version when third digit is smaller"() {
+        when:
+            final result = InstallationDescription.versionMatchOrAfter("5.5.0-rc1", "5.5.5")
+        then:
+            !result
+    }
+    
+    def "should detect next version with only digits when first digit is bigger"() {
+        when:
+            final result = InstallationDescription.versionMatchOrAfter("6.7.5", "5.5.0")
+        then:
+            result
+    }
+
+    def "should detect next alphanumeric version when first digit is bigger"() {
+        when:
+            final result = InstallationDescription.versionMatchOrAfter("6.7.5-rc1", "5.5.0")
+        then:
+            result
+    }
+
+    def "should detect next version with only digits when second digit is bigger"() {
+        when:
+            final result = InstallationDescription.versionMatchOrAfter("5.6.5", "5.5.0")
+        then:
+            result
+    }
+
+    def "should detect next alphanumeric version when second digit is bigger"() {
+        when:
+            final result = InstallationDescription.versionMatchOrAfter("5.6.5-rc1", "5.5.0")
+        then:
+            result
+    }
+    
+    def "should detect next version with only digits when third digit is bigger"() {
+        when:
+            final result = InstallationDescription.versionMatchOrAfter("5.5.6", "5.5.5")
+        then:
+            result
+    }
+
+    def "should detect next alphanumeric version when third digit is bigger"() {
+        when:
+            final result = InstallationDescription.versionMatchOrAfter("5.5.6-rc1", "5.5.5")
+        then:
+            result
+    }
+    
+    def "should detect same version with only digits"() {
+        when:
+            final result = InstallationDescription.versionMatchOrAfter("5.5.5", "5.5.5")
+        then:
+            result
+    }
+
+    def "should detect previous alphanumeric version"() {
+        when:
+            final result = InstallationDescription.versionMatchOrAfter("5.5.5-rc1", "5.5.5")
+        then:
+            !result
+    }
+}

--- a/test-base/src/main/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationBaseSpec.groovy
+++ b/test-base/src/main/groovy/pl/allegro/tech/embeddedelasticsearch/PluginsInstallationBaseSpec.groovy
@@ -58,6 +58,58 @@ abstract class PluginsInstallationBaseSpec extends Specification {
             embeddedElastic.stop()
     }
 
+    def "should reuse plugins on restart"() {
+        given:
+            final installationDirectory = new File(System.getProperty("java.io.tmpdir"), "embedded-elasticsearch-for-reuse")
+            installationDirectory.deleteDir()
+            baseEmbeddedElastic()
+                    .withCleanInstallationDirectoryOnStop(false)
+                    .withInstallationDirectory(installationDirectory)
+                    .withPlugin(pluginByUrlUrl())
+                    .build().start().stop()
+            final pluginCustomFile = new File(installationDirectory.listFiles()
+                    .findAll { it.isDirectory() }
+                    .find { it.name.startsWith("elasticsearch-")}, "plugins/" + pluginByUrlName() + "/foo.txt")
+            pluginCustomFile.createNewFile();
+            final embeddedElastic = baseEmbeddedElastic()
+                    .withCleanInstallationDirectoryOnStop(false)
+                    .withInstallationDirectory(installationDirectory)
+                    .withPlugin(pluginByUrlUrl())
+                    .build()
+
+        when:
+            embeddedElastic.start()
+
+        then:
+            pluginCustomFile.exists()
+
+        cleanup:
+            if (embeddedElastic) embeddedElastic.stop()
+            installationDirectory.deleteDir()
+    }
+
+    def "should reuse only specified plugins on restart"() {
+        given:
+            baseEmbeddedElastic()
+                    .withCleanInstallationDirectoryOnStop(false)
+                    .withPlugin(pluginByUrlUrl())
+                    .withPlugin(pluginByName())
+                    .build().start().stop()
+            final embeddedElastic = baseEmbeddedElastic()
+                    .withCleanInstallationDirectoryOnStop(false)
+                    .withPlugin(pluginByName())
+                    .build()
+
+        when:
+            embeddedElastic.start()
+
+        then:
+            fetchInstalledPluginsList() == [pluginByNameName()].toSet()
+
+        cleanup:
+            if (embeddedElastic) embeddedElastic.stop()
+    }
+
     abstract EmbeddedElastic.Builder baseEmbeddedElastic()
 
     Set<String> fetchInstalledPluginsList() {


### PR DESCRIPTION
Fix for #78 

* In case withCleanInstallationDirectoryOnStop is false and we have a bin folder, we assume that we want to reuse the folder
* Uninstall all the plugins that were already installed and that were not explicitly configured
