### PR TITLE
 Adds Junit Rule and method isStarted

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,32 @@ When you are done with creating it, you can start it real simple:
 ```java
 embeddedElastic.start()
 ```
+You can also use @Rule or @ClassRule to start embedded elastic.
+
+Using this feature you do not have to worry about starting and stopping elastic in your tests.
+
+Simple setup:
+
+```java
+@ClassRule
+public static EmbeddedElasticRule embeddedElasticRule = new EmbeddedElasticRule("index_name", 9200);
+```
+
+Custom Setup:
+
+```java
+@ClassRule
+public static EmbeddedElasticRule embeddedElasticRule = new EmbeddedElasticRule(EmbeddedElastic.builder()
+        .withElasticVersion("6.8.0")
+        .withSetting(PopularProperties.HTTP_PORT, 9200)
+        .withSetting(PopularProperties.CLUSTER_NAME, "cluster_test")
+        .withSetting("cluster.routing.allocation.disk.threshold_enabled", false)
+        .withStartTimeout(2, TimeUnit.MINUTES)
+        .withIndex("test_builder")
+        .withDownloadDirectory(new File("./"))
+        .withInstallationDirectory(new File("./"))
+        .build());
+```
 
 And that's all, you can connect to your embedded-elastic instance on specified port and use it in your tests.
 
@@ -82,6 +108,7 @@ Availabe `JavaHomeOption` options
 | Method | Description |
 | ------------- | ------------- |
 | `start()` | downloads Elasticsearch and specified plugins, setups everything and finally starts your Elasticsearch instance |
+| `isStarted()` | Checks if you have an instance of Elasticsearch available |
 | `stop()` | stops your Elasticsearch instance and removes all data |
 | `index` | index your document, comes with variants that take only document, or document and it's id |
 | `deleteIndex(String indexName)`, `deleteIndices()`  | deletes index with name specified during EmbeddedElastic creation |

--- a/README.md
+++ b/README.md
@@ -32,18 +32,21 @@ When you are done with creating it, you can start it real simple:
 ```java
 embeddedElastic.start()
 ```
-You can also use @Rule or @ClassRule to start embedded elastic.
 
+And that's all, you can connect to your embedded-elastic instance on specified port and use it in your tests.
+
+## Junit Rule
+
+You can also use `@Rule` or `@ClassRule` to start embedded elastic.
 Using this feature you do not have to worry about starting and stopping elastic in your tests.
-
-Simple setup:
+simple setup:
 
 ```java
 @ClassRule
 public static EmbeddedElasticRule embeddedElasticRule = new EmbeddedElasticRule("index_name", 9200);
 ```
 
-Custom Setup:
+custom Setup:
 
 ```java
 @ClassRule
@@ -59,7 +62,6 @@ public static EmbeddedElasticRule embeddedElasticRule = new EmbeddedElasticRule(
         .build());
 ```
 
-And that's all, you can connect to your embedded-elastic instance on specified port and use it in your tests.
 
 ## Available builder options
 

--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/EmbeddedElastic.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/EmbeddedElastic.java
@@ -9,15 +9,8 @@ import java.io.InputStream;
 import java.net.Proxy;
 import java.net.URL;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toList;
@@ -279,6 +272,10 @@ public final class EmbeddedElastic {
      */
     public int getHttpPort() {
         return elasticServer.getHttpPort();
+    }
+
+    public boolean isStarted() {
+        return elasticServer.isStarted();
     }
 
     public static final class Builder {

--- a/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticRule.java
+++ b/core/src/main/java/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticRule.java
@@ -1,0 +1,71 @@
+package pl.allegro.tech.embeddedelasticsearch;
+
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+public class EmbeddedElasticRule implements TestRule {
+
+    private static final Integer DEFAULT_PORT = 9200;
+
+    public EmbeddedElastic embeddedElastic;
+    private Integer port = 0;
+    private String index;
+
+    public EmbeddedElasticRule(String index, Integer port) {
+        this.port = port;
+        this.index = index;
+    }
+
+    public EmbeddedElasticRule(EmbeddedElastic builder) {
+        this.embeddedElastic = builder;
+    }
+
+    @Override
+    public Statement apply(final Statement base,
+                           final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                validate();
+                startElastic();
+
+                try {
+                    base.evaluate();
+                } finally {
+                    embeddedElastic.stop();
+                }
+            }
+        };
+    }
+
+    private void startElastic() throws IOException, InterruptedException {
+        if (embeddedElastic != null) {
+            embeddedElastic.start();
+        } else {
+            embeddedElastic = EmbeddedElastic.builder()
+                    .withElasticVersion("6.8.0")
+                    .withSetting(PopularProperties.HTTP_PORT, port != 0 ? port : DEFAULT_PORT)
+                    .withSetting(PopularProperties.CLUSTER_NAME, "test_cluster")
+                    .withSetting("cluster.routing.allocation.disk.threshold_enabled", false)
+                    .withStartTimeout(2, TimeUnit.MINUTES)
+                    .withIndex(index)
+                    .withDownloadDirectory(new File("./"))
+                    .withInstallationDirectory(new File("./"))
+                    .build();
+            embeddedElastic.start();
+        }
+    }
+
+    private void validate() {
+        if (embeddedElastic != null) return;
+        if (index == null || index.replace(" ", "").isEmpty()) {
+            throw new IllegalArgumentException("Index can not be null");
+        }
+    }
+}

--- a/test-base/build.gradle
+++ b/test-base/build.gradle
@@ -4,4 +4,5 @@ dependencies {
     compile group: 'org.spockframework', name: 'spock-core', version: '1.0-groovy-2.4'
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     compile group: 'org.skyscreamer', name: 'jsonassert', version: '1.3.0'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/test-base/src/main/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticRuleBuilderTest.java
+++ b/test-base/src/main/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticRuleBuilderTest.java
@@ -1,0 +1,35 @@
+package pl.allegro.tech.embeddedelasticsearch;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+import static junit.framework.TestCase.assertTrue;
+
+public class EmbeddedElasticRuleBuilderTest {
+
+    @ClassRule
+    public static EmbeddedElasticRule embeddedElasticRule = new EmbeddedElasticRule(EmbeddedElastic.builder()
+            .withElasticVersion("6.8.0")
+            .withSetting(PopularProperties.HTTP_PORT, 9200)
+            .withSetting(PopularProperties.CLUSTER_NAME, "cluster_test")
+            .withSetting("cluster.routing.allocation.disk.threshold_enabled", false)
+            .withStartTimeout(2, TimeUnit.MINUTES)
+            .withIndex("test_builder")
+            .withDownloadDirectory(new File("./"))
+            .withInstallationDirectory(new File("./"))
+            .build());
+
+    @Test
+    public void shouldStartElastic() {
+        assertTrue(embeddedElasticRule.embeddedElastic.isStarted());
+    }
+
+    @Test
+    public void shouldCreateIndex() {
+        Boolean createdIndex = TestHelper.existsIndex("test_builder", 9200);
+        assertTrue(createdIndex);
+    }
+}

--- a/test-base/src/main/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticRuleTest.java
+++ b/test-base/src/main/groovy/pl/allegro/tech/embeddedelasticsearch/EmbeddedElasticRuleTest.java
@@ -1,0 +1,24 @@
+package pl.allegro.tech.embeddedelasticsearch;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+
+public class EmbeddedElasticRuleTest {
+
+    @ClassRule
+    public static EmbeddedElasticRule embeddedElasticRule = new EmbeddedElasticRule("index_name", 9200);
+
+    @Test
+    public void shouldStartElastic() {
+        assertTrue(embeddedElasticRule.embeddedElastic.isStarted());
+    }
+
+    @Test
+    public void shouldCreateIndex() {
+        Boolean createdIndex = TestHelper.existsIndex("index_name", 9200);
+        assertTrue(createdIndex);
+    }
+
+}

--- a/test-base/src/main/groovy/pl/allegro/tech/embeddedelasticsearch/TestHelper.java
+++ b/test-base/src/main/groovy/pl/allegro/tech/embeddedelasticsearch/TestHelper.java
@@ -1,0 +1,14 @@
+package pl.allegro.tech.embeddedelasticsearch;
+
+import org.apache.http.client.methods.HttpHead;
+
+import static pl.allegro.tech.embeddedelasticsearch.HttpStatusCodes.OK;
+
+public class TestHelper {
+
+    public static boolean existsIndex(String index, Integer port) {
+        final HttpClient httpClient = new HttpClient();
+        HttpHead request = new HttpHead("http://localhost:" + port + "/" + index);
+        return httpClient.execute(request, response -> response.getStatusLine().getStatusCode() == OK);
+    }
+}


### PR DESCRIPTION
`Motivation`:

My integration tests were getting very polluted and with duplicate code (start and stop)
I also find it elegant not to have to worry about managing the start and stop of the service.
In some cases I needed to validate if the service was "on" so I also added an `isStarted()` method.